### PR TITLE
Fix parser json check and markdown filename

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -33,7 +33,7 @@ def parse_chat_json(file_path: str) -> pd.DataFrame:
             chat_data = item['data']['tabs']
             break
     
-    if not chat_data:
+    if chat_data is None:
         raise KeyError("Could not find chat data in the JSON file")
     
     # List to store all bubble data
@@ -86,7 +86,7 @@ def export_chats_to_markdown(chats_data: List[Dict[str, Any]], output_dir: str =
     
     for chat in chats_data:
         # Create filename based on chat ID
-        workspace_id = os.path.basename(os.path.dirname(output_dir)) if output_dir != '.' else ''
+        workspace_id = Path(output_dir).name if output_dir != '.' else ''
         filename = f"chat_{workspace_id}_{chat['id']}.md"
         filepath = output_path / filename
         


### PR DESCRIPTION
## Summary
- avoid raising KeyError when chat data is empty
- use output directory name when creating markdown filenames

## Testing
- `pytest -q`
- `python -m py_compile src/parser.py`

------
https://chatgpt.com/codex/tasks/task_e_684344d444cc83289f8f819ac5728bea