### PR TITLE
Ensure DB connection closes on read failure

### DIFF
--- a/src/extractor.py
+++ b/src/extractor.py
@@ -53,6 +53,7 @@ def read_sqlite_db(db_path: str) -> Optional[List[Dict[str, Any]]]:
     Returns:
         List of dictionaries containing chat data or None if extraction failed
     """
+    conn = None
     try:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
@@ -79,12 +80,15 @@ def read_sqlite_db(db_path: str) -> Optional[List[Dict[str, Any]]]:
             except json.JSONDecodeError:
                 logger.debug("Non-JSON data found for key: %s", key)
         
-        conn.close()
         return chat_data
-        
+
     except sqlite3.Error as e:
         logger.error("SQLite error: %s", str(e))
         return None
+
+    finally:
+        if conn:
+            conn.close()
 
 
 def get_project_name(workspace_path: str) -> str:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,30 @@
+import sqlite3
+
+from src.extractor import read_sqlite_db
+
+class DummyCursor:
+    def execute(self, *args, **kwargs):
+        raise sqlite3.Error("boom")
+
+    def fetchall(self):
+        return []
+
+class DummyConnection:
+    def __init__(self):
+        self.closed = False
+    def cursor(self):
+        return DummyCursor()
+    def close(self):
+        self.closed = True
+
+
+def test_read_sqlite_db_closes_on_error(monkeypatch):
+    dummy_conn = DummyConnection()
+    def dummy_connect(path):
+        return dummy_conn
+    monkeypatch.setattr(sqlite3, 'connect', dummy_connect)
+
+    result = read_sqlite_db('dummy')
+
+    assert result is None
+    assert dummy_conn.closed


### PR DESCRIPTION
## Summary
- close DB connection in `read_sqlite_db` using a `finally` block
- add regression test to ensure the connection closes when a query fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843669a8784832899dc8589a1c3e05f