### PR TITLE
Add basic parse_chat_json test

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -32,8 +32,9 @@ def parse_chat_json(file_path: str) -> pd.DataFrame:
     # Find the chat data in the JSON structure
     chat_data = None
     for item in data:
-        if 'data' in item and 'tabs' in item.get('data', {}):
-            chat_data = item['data']['tabs']
+        item_data = item.get('data')
+        if isinstance(item_data, dict) and 'tabs' in item_data:
+            chat_data = item_data['tabs']
             break
     
     if chat_data is None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+import pytest
+import site
+import sys
+
+# Ensure pandas from the local virtual environment is importable
+root_dir = Path(__file__).resolve().parent.parent
+venv_site = root_dir / '.venv' / 'lib' / 'python3.10' / 'site-packages'
+if venv_site.exists():
+    site.addsitedir(str(venv_site))
+
+pandas = pytest.importorskip('pandas')
+
+from src.parser import parse_chat_json
+
+
+def test_parse_chat_json_example():
+    examples_dir = Path(__file__).resolve().parent.parent / 'examples'
+    json_file = examples_dir / 'chat_data_de5562f3e8c437246be75a12e9e89d4d.json'
+    df = parse_chat_json(str(json_file))
+    expected_columns = ['tabId', 'chatTitle', 'type', 'messageType', 'id', 'requestId', 'text', 'rawText', 'modelType', 'hasCodeBlock', 'timestamp']
+    assert list(df.columns) == expected_columns
+    assert len(df) == 8


### PR DESCRIPTION
## Summary
- update parser to avoid failing when unrelated data is present
- add pytest for parse_chat_json using example JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684366a4e2b48328973d1ab70309ec2e